### PR TITLE
Remove logging and two small CSS adjustments

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,3 +1,12 @@
+.Modal-header .Avatar {
+    margin-right: 15px;
+}
+
+#eventdescription p {
+    font-size: 1rem;
+    font-weight: bold;
+}
+
 @media (max-width: 767px){
     .fc-toolbar-chunk {
         margin: 10px 5px 0px 0px;

--- a/src/Integrations/EventResource.php
+++ b/src/Integrations/EventResource.php
@@ -10,15 +10,8 @@ use Carbon\Carbon;
 
 class EventResource extends Resource
 {
-    public function __construct()
-    {
-        app('log')->debug("[Webbinaro\AdvCalendar] Resource Initialized");
-    }
-
-
     public function query(): Builder
     {
-        app('log')->debug("[Webbinaro\AdvCalendar] Resource Queried");
         return Model::query();
     }
 


### PR DESCRIPTION
I removed a few lines to prevent log files from being created daily. I'm sure these were there while this was being built to troubleshoot. But, this extension seems fairly stable now. If there's a better way to prevent the logging feel free to change that part however you'd like.

Also, I added a couple new CSS rules which moves the avatar in the modal to the left a little, away from the close window icon. And, the other CSS rule simply makes the main description font bigger and bold to make it stand out from the other details a little.

Nothing major, I mainly just wanted to stop the logging. 🙂