### PR TITLE
Show only future events in list & improved state management

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@flarum/prettier-config": "^1.0.0",
-        "prettier": "^2.8.4"
+        "prettier": "^3.0.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2880,15 +2880,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -5640,9 +5640,9 @@
       }
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true
     },
     "punycode": {
@@ -5759,9 +5759,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
     },
     "serialize-javascript": {
       "version": "6.0.1",

--- a/js/package.json
+++ b/js/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@flarum/prettier-config": "^1.0.0",
-    "prettier": "^2.8.4"
+    "prettier": "^3.0.1"
   },
   "scripts": {
     "dev": "webpack --mode development --watch",

--- a/js/src/forum/components/CalendarPage.js
+++ b/js/src/forum/components/CalendarPage.js
@@ -8,6 +8,7 @@ import EventTeaser from './EventTeaser';
 import Button from 'flarum/common/components/Button';
 import EditEventModal from './EditEventModal';
 import LogInModal from 'flarum/forum/components/LogInModal';
+import CalendarState from '../states/CalendarState';
 
 export default class CalendarPage extends Page {
   oninit(vnode) {
@@ -83,7 +84,7 @@ export default class CalendarPage extends Page {
   }
 
   onupdate(vnode) {
-    this.renderCalendar(vnode);
+    this.state.refresh(false);
   }
 
   async renderCalendar(vnode) {
@@ -98,9 +99,9 @@ export default class CalendarPage extends Page {
       locale: app.translator.getLocale(), // the initial locale
       headerToolbar: { center: 'dayGridMonth,listYear' }, // buttons for switching between views
       initialView: 'dayGridMonth',
-      eventClick: function (info) {
+      eventClick: async function (info) {
         info.jsEvent.preventDefault();
-        for (var event of this.events) {
+        for (let event of (await this.state?.getEvents()) || []) {
           if (event.id() === info.event.extendedProps.eventId) {
             app.modal.show(EventTeaser, { event: event });
             break;
@@ -110,15 +111,14 @@ export default class CalendarPage extends Page {
       dateClick: function (info) {
         openModal(info);
       },
-      events: function (info, successCallback, failureCallbacks) {
-        app.store.find('events', { start: info.start.toISOString(), end: info.end.toISOString(), sort: 'event_start' }).then((results) => {
-          this.events = results;
-          successCallback(results);
-        });
-      }.bind(this),
+      events: (info, successCb, failureCb) => this.state?.getEvents(info, successCb, failureCb) || [],
       eventDataTransform: this.flarumToFullCalendarEvent,
     });
     calendar.render();
+
+    this.state = new CalendarState(calendar, this);
+    app.calendarState = this.state;
+    this.state.refresh();
   }
 
   openCreateModal(info) {
@@ -126,11 +126,13 @@ export default class CalendarPage extends Page {
       return;
     }
 
+    const refresh = this.state.refresh.bind(this.state);
+
     if (app.session.user != undefined) {
       if (info.dateStr) {
-        app.modal.show(EditEventModal, { withStart: info.dateStr });
+        app.modal.show(EditEventModal, { withStart: info.dateStr, refresh });
       } else {
-        app.modal.show(EditEventModal);
+        app.modal.show(EditEventModal, { refresh });
       }
     } else {
       app.modal.show(LogInModal);

--- a/js/src/forum/components/CalendarPage.js
+++ b/js/src/forum/components/CalendarPage.js
@@ -97,8 +97,24 @@ export default class CalendarPage extends Page {
     // console.debug(`Loading Full Calendar with locale: ${app.translator.getLocale()}`);
     const calendar = new FullCalendar.Calendar(calendarEl, {
       locale: app.translator.getLocale(), // the initial locale
-      headerToolbar: { center: 'dayGridMonth,listYear' }, // buttons for switching between views
+      headerToolbar: { center: 'dayGridMonth,listYearFromToday' }, // buttons for switching between views
       initialView: 'dayGridMonth',
+      views: {
+        listYearFromToday: {
+          type: 'list',
+          visibleRange: function (currentDate) {
+            // Generate a new date for manipulating in the next step
+            var startDate = new Date(currentDate.valueOf());
+            var endDate = new Date(currentDate.valueOf());
+
+            // Adjust the end date to one year into the future
+            endDate.setFullYear(endDate.getFullYear() + 1);
+
+            return { start: startDate, end: endDate };
+          },
+          listDaySideFormat: { weekday: 'long' }, // day-of-week is nice-to-have
+        },
+      },
       eventClick: async function (info) {
         info.jsEvent.preventDefault();
         for (let event of (await this.state?.getEvents()) || []) {

--- a/js/src/forum/components/EditEventModal.js
+++ b/js/src/forum/components/EditEventModal.js
@@ -117,6 +117,8 @@ export default class EditEventModal extends Modal {
       event_end: this.event_end(),
     });
 
+    this.attrs.refresh();
+
     this.hide();
   }
 }

--- a/js/src/forum/components/EventFragment.js
+++ b/js/src/forum/components/EventFragment.js
@@ -54,7 +54,7 @@ export default class EventFragment extends Component {
   }
 
   editLaunch() {
-    app.modal.show(EditEventModal, { event: this.attrs.event });
+    app.modal.show(EditEventModal, { event: this.attrs.event, refresh: app.calendarState.refresh.bind(app.calendarState) });
   }
 
   deleteEvent() {

--- a/js/src/forum/states/CalendarState.js
+++ b/js/src/forum/states/CalendarState.js
@@ -1,0 +1,39 @@
+import app from 'flarum/forum/app';
+
+export default class CalendarState {
+  constructor(calendar, calendarPage) {
+    this.calendar = calendar;
+    this.events = null;
+    this.info = null;
+  }
+
+  refresh(clear = true) {
+    if (clear) {
+      this.events = null;
+      this.info = null;
+    }
+
+    this.calendar.refetchEvents();
+  }
+
+  async getEvents(info, successCallback, failureCallbacks) {
+    if (info && ((this.info?.startStr != info.startStr && this.info?.endStr != info.endStr) || !this.events)) {
+      this.info = info;
+      this.successCallback = successCallback;
+      await this.fetchEvents(info, successCallback, failureCallbacks);
+    }
+
+    return this.events || [];
+  }
+
+  async fetchEvents(info, successCallback, failureCallbacks) {
+    const results = await app.store.find('events', {
+      start: info.start.toISOString(),
+      end: info.end.toISOString(),
+      sort: 'event_start',
+    });
+
+    this.events = results;
+    successCallback(results);
+  }
+}

--- a/js/src/forum/utils/dynamicallyLoadLib.js
+++ b/js/src/forum/utils/dynamicallyLoadLib.js
@@ -1,22 +1,22 @@
 const libs = {
   fullcalendarCore: {
-    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.7/index.global.min.js',
+    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.8/index.global.min.js',
     loaded: () => typeof FullCalendar !== 'undefined',
   },
   fullcalendarLocales: {
-    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.7/locales-all.global.min.js',
+    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.8/locales-all.global.min.js',
     loaded: () => typeof FullCalendar !== 'undefined' && FullCalendar.globalLocales.length > 2,
   },
   fullcalendarDayGrid: {
-    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@6.1.7/index.global.min.js',
+    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@6.1.8/index.global.min.js',
     loaded: () => typeof FullCalendar !== 'undefined' && FullCalendar.globalPlugins.find((p) => p.name === '@fullcalendar/daygrid'),
   },
   fullcalendarInteraction: {
-    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@6.1.7/index.global.min.js',
+    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@6.1.8/index.global.min.js',
     loaded: () => typeof FullCalendar !== 'undefined' && FullCalendar.globalPlugins.find((p) => p.name === '@fullcalendar/interaction'),
   },
   fullcalendarList: {
-    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/list@6.1.7/index.global.min.js',
+    js: 'https://cdn.jsdelivr.net/npm/@fullcalendar/list@6.1.8/index.global.min.js',
     loaded: () => typeof FullCalendar !== 'undefined' && FullCalendar.globalPlugins.find((p) => p.name === '@fullcalendar/list'),
   },
 


### PR DESCRIPTION
As the list view was showing all event the of current year, and that list could be quite long, I thought it would be better to start the year at the date of now and show the event of the next _floating_ year. Else, users might have to scroll a lot, to find current events!

While doing that change, I made some minor updates to libraries and improved state management to avoid re-rendering the whole calendar so often and avoid fetching data from the server when there has actually been no changes.

@eddiewebb, would you be so kind and merge this PR and release a new version with the changes? Thanks in advance.
